### PR TITLE
release(v0.0.4): publishable tag cut from merged main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [0.0.4] - 2026-03-09
+
+### Changed
+- Release commit aligned to current `main` after PR #81 merge.
+- Crate publication flow finalized through tag-driven `publish-crates` workflow.
+
 ## [0.0.3] - 2026-02-22
 
 ### Added
@@ -27,4 +33,3 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Added
 - Initial baseline features and project scaffolding for static HTTP serving and core request/response handling.
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 # General project metadata
 name = "http-handle"                        # The name of the library
-version = "0.0.3"                           # Current version of the crate
+version = "0.0.4"                           # Current version of the crate
 authors = ["HTTP Handle Contributors"]      # Library contributors (auto-generated if not defined)
 edition = "2024"                            # Rust edition
 rust-version = "1.88.0"                     # Minimum supported Rust version

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-http-handle = "0.0.3"
+http-handle = "0.0.4"
 ```
 
 Minimum supported Rust version (MSRV): `1.88.0`.
@@ -113,7 +113,7 @@ Supporting docs:
 
 ## Release Publication
 
-`crates.io` publishing is tag-driven. After merge to `main`, publish by pushing a `v*` tag (for example `v0.0.3`) or by manually running the publish workflow.
+`crates.io` publishing is tag-driven. After merge to `main`, publish by pushing a `v*` tag (for example `v0.0.4`) or by manually running the publish workflow.
 
 ## Examples
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -2,6 +2,27 @@
 
 This guide tracks migration steps between `http-handle` release lines.
 
+## 0.0.3 -> 0.0.4
+
+### What Changed
+- Release publication is now anchored to the merged `main` state from PR #81.
+- Documentation and release notes were synchronized for the new release tag.
+
+### Migration Steps
+1. Update dependency:
+
+```toml
+[dependencies]
+http-handle = "0.0.4"
+```
+
+2. Re-run validation gates:
+
+```bash
+cargo check --all-features
+cargo test --all-features
+```
+
 ## 0.0.2 -> 0.0.3
 
 ### What Changed

--- a/docs/TUTORIALS.md
+++ b/docs/TUTORIALS.md
@@ -19,7 +19,7 @@ echo '<h1>Hello from http-handle</h1>' > public/index.html
 
 ```toml
 [dependencies]
-http-handle = "0.0.3"
+http-handle = "0.0.4"
 ```
 
 3. Start the server:


### PR DESCRIPTION
## Summary
- bump crate version to 0.0.4
- update release-facing docs/examples to 0.0.4
- add 0.0.4 changelog entry for release publication

## Validation
- cargo check --all-features
- cargo test --all-features