### PR TITLE
ci: fix release-artifacts and sbom-attestation workflow failures

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: x86_64-unknown-linux-musl
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
       - uses: taiki-e/install-action@29bf2ca669cb9c2490809a50b325502d582072a1 # cargo-zigbuild
       - name: Build static binary
         run: cargo zigbuild --release --bin http-handle --target x86_64-unknown-linux-musl
@@ -38,6 +39,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:

--- a/.github/workflows/sbom-attestation.yml
+++ b/.github/workflows/sbom-attestation.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0
         with:
-          path: ./target/release/http-handle
+          path: ./target/release
           output-file: sbom.spdx.json
           format: spdx-json
       - name: Upload SBOM artifact


### PR DESCRIPTION
## Summary
- install Zig before `cargo-zigbuild` in release artifacts workflow
- set up QEMU before multi-arch buildx build
- fix `sbom-action` path to scan release directory

## Root causes addressed
- missing Zig binary in static-linux job
- missing QEMU emulation for linux/arm64 image build
- sbom-action configured with file path while expecting directory source

## Validation
- `bash scripts/ci_workflow_audit.sh`

Designed by Sebastien Rousseau
Engineered with Euxis
https://euxis.co
